### PR TITLE
Test P-384

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ p256 = { version = "=0.13.0-pre", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
+p384 = { version = "=0.13.0-pre", default-features = false, features = [
+  "hash2curve",
+  "voprf",
+] }
 proptest = "1"
 rand = "0.8"
 regex = "1"
@@ -62,3 +66,4 @@ targets = []
 
 [patch.crates-io]
 p256 = { git = "https://github.com/RustCrypto/elliptic-curves", rev = "136fed7944d53c0508b1a93cd97bdab46891bcf7" }
+p384 = { git = "https://github.com/RustCrypto/elliptic-curves", rev = "136fed7944d53c0508b1a93cd97bdab46891bcf7" }

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -15,6 +15,7 @@ use crate::{Error, Group, Result};
 #[test]
 fn test_group_properties() -> Result<()> {
     use p256::NistP256;
+    use p384::NistP384;
 
     #[cfg(feature = "ristretto255")]
     {
@@ -26,6 +27,9 @@ fn test_group_properties() -> Result<()> {
 
     test_identity_element_error::<NistP256>()?;
     test_zero_scalar_error::<NistP256>()?;
+
+    test_identity_element_error::<NistP384>()?;
+    test_zero_scalar_error::<NistP384>()?;
 
     Ok(())
 }

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -425,6 +425,7 @@ mod tests {
     #[test]
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
+        use p384::NistP384;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -444,6 +445,13 @@ mod tests {
 
         zeroize_oprf_client::<NistP256>();
         zeroize_oprf_server::<NistP256>();
+
+        base_retrieval::<NistP384>();
+        base_inversion_unsalted::<NistP384>();
+        server_evaluate::<NistP384>();
+
+        zeroize_oprf_client::<NistP384>();
+        zeroize_oprf_server::<NistP384>();
 
         Ok(())
     }

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -965,6 +965,7 @@ mod tests {
     #[test]
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
+        use p384::NistP384;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -984,6 +985,13 @@ mod tests {
 
         zeroize_verifiable_client::<NistP256>();
         zeroize_verifiable_server::<NistP256>();
+
+        verifiable_retrieval::<NistP384>();
+        verifiable_bad_public_key::<NistP384>();
+        verifiable_server_evaluate::<NistP384>();
+
+        zeroize_verifiable_client::<NistP384>();
+        zeroize_verifiable_server::<NistP384>();
 
         Ok(())
     }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -389,6 +389,7 @@ mod test {
             }
 
             let _ = $item::<p256::NistP256>::deserialize(&$bytes[..]);
+            let _ = $item::<p384::NistP384>::deserialize(&$bytes[..]);
         };
     }
 

--- a/src/tests/test_cfrg_vectors.rs
+++ b/src/tests/test_cfrg_vectors.rs
@@ -87,6 +87,7 @@ macro_rules! json_to_test_vectors {
 #[test]
 fn test_vectors() -> Result<()> {
     use p256::NistP256;
+    use p384::NistP384;
 
     let rfc: Value = serde_json::from_str(rfc_to_json(super::cfrg_vectors::VECTORS).as_str())
         .expect("Could not parse json");
@@ -158,6 +159,33 @@ fn test_vectors() -> Result<()> {
     test_poprf_blind_evaluate::<NistP256>(&p256_poprf_tvs)?;
     test_poprf_finalize::<NistP256>(&p256_poprf_tvs)?;
     test_poprf_evaluate::<NistP256>(&p256_poprf_tvs)?;
+
+    let p384_oprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P384-SHA384"), String::from("OPRF"));
+    assert_ne!(p384_oprf_tvs.len(), 0);
+    test_oprf_seed_to_key::<NistP384>(&p384_oprf_tvs)?;
+    test_oprf_blind::<NistP384>(&p384_oprf_tvs)?;
+    test_oprf_blind_evaluate::<NistP384>(&p384_oprf_tvs)?;
+    test_oprf_finalize::<NistP384>(&p384_oprf_tvs)?;
+    test_oprf_evaluate::<NistP384>(&p384_oprf_tvs)?;
+
+    let p384_voprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P384-SHA384"), String::from("VOPRF"));
+    assert_ne!(p384_voprf_tvs.len(), 0);
+    test_voprf_seed_to_key::<NistP384>(&p384_voprf_tvs)?;
+    test_voprf_blind::<NistP384>(&p384_voprf_tvs)?;
+    test_voprf_blind_evaluate::<NistP384>(&p384_voprf_tvs)?;
+    test_voprf_finalize::<NistP384>(&p384_voprf_tvs)?;
+    test_voprf_evaluate::<NistP384>(&p384_voprf_tvs)?;
+
+    let p384_poprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P384-SHA384"), String::from("POPRF"));
+    assert_ne!(p384_poprf_tvs.len(), 0);
+    test_poprf_seed_to_key::<NistP384>(&p384_poprf_tvs)?;
+    test_poprf_blind::<NistP384>(&p384_poprf_tvs)?;
+    test_poprf_blind_evaluate::<NistP384>(&p384_poprf_tvs)?;
+    test_poprf_finalize::<NistP384>(&p384_poprf_tvs)?;
+    test_poprf_evaluate::<NistP384>(&p384_poprf_tvs)?;
 
     Ok(())
 }

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -834,6 +834,7 @@ mod tests {
     #[test]
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
+        use p384::NistP384;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -857,6 +858,15 @@ mod tests {
 
         zeroize_voprf_client::<NistP256>();
         zeroize_voprf_server::<NistP256>();
+
+        verifiable_retrieval::<NistP384>();
+        verifiable_batch_retrieval::<NistP384>();
+        verifiable_bad_public_key::<NistP384>();
+        verifiable_batch_bad_public_key::<NistP384>();
+        verifiable_server_evaluate::<NistP384>();
+
+        zeroize_voprf_client::<NistP384>();
+        zeroize_voprf_server::<NistP384>();
 
         Ok(())
     }


### PR DESCRIPTION
This just tests P-384 support and builds on top of https://github.com/RustCrypto/elliptic-curves/pull/600.
We still have to wait for new versions to be released.

Builds on top of https://github.com/facebook/voprf/pull/101.
Fixes #81.