### PR TITLE
Replace `json` with `serde_json`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ zeroize = { version = "1.5", default-features = false }
 [dev-dependencies]
 generic-array = { version = "0.14", features = ["more_lengths"] }
 hex = "0.4"
-json = "0.12"
 p256 = { version = "0.12", default-features = false, features = [
   "hash2curve",
   "voprf",
@@ -52,6 +51,7 @@ p256 = { version = "0.12", default-features = false, features = [
 proptest = "1"
 rand = "0.8"
 regex = "1"
+serde_json = "1"
 sha2 = "0.10"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
`json` was flagged by `cargo-audit` as unmaintained, which is my impression too.