### PR TITLE
Depend on `ProjectivePoint: ToEncodedPoint`

### DIFF
--- a/src/group/elliptic_curve.rs
+++ b/src/group/elliptic_curve.rs
@@ -23,7 +23,7 @@ use crate::{Error, InternalError, Result};
 impl<C> Group for C
 where
     C: GroupDigest,
-    ProjectivePoint<Self>: CofactorGroup,
+    ProjectivePoint<Self>: CofactorGroup + ToEncodedPoint<Self>,
     FieldSize<Self>: ModulusSize,
     AffinePoint<Self>: FromEncodedPoint<Self> + ToEncodedPoint<Self>,
     Scalar<Self>: FromOkm,
@@ -65,8 +65,7 @@ where
     }
 
     fn serialize_elem(elem: Self::Elem) -> GenericArray<u8, Self::ElemLen> {
-        let affine: AffinePoint<Self> = elem.into();
-        let bytes = affine.to_encoded_point(true);
+        let bytes = elem.to_encoded_point(true);
         let bytes = bytes.as_bytes();
         let mut result = GenericArray::default();
         result[..bytes.len()].copy_from_slice(bytes);


### PR DESCRIPTION
This reverts the unfortunate changes that had to be made in #91.
It was fixed in https://github.com/RustCrypto/elliptic-curves/pull/722.

This will actually require downstream users to update their `primeorder` dependency to v0.12.1, personally I don't think it is a problem, but the gain is also very minor.