### PR TITLE
Use explicit crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ version = "0.5.0-pre.1"
 [features]
 alloc = []
 danger = []
-default = ["ristretto255-ciphersuite", "serde"]
-ristretto255 = ["curve25519-dalek", "generic-array/more_lengths"]
-ristretto255-ciphersuite = ["ristretto255", "sha2"]
-serde = ["generic-array/serde", "serde_"]
+default = ["ristretto255-ciphersuite", "dep:serde"]
+ristretto255 = ["dep:curve25519-dalek", "generic-array/more_lengths"]
+ristretto255-ciphersuite = ["ristretto255", "dep:sha2"]
+serde = ["generic-array/serde", "dep:serde"]
 std = ["alloc"]
 
 [dependencies]
@@ -35,7 +35,7 @@ elliptic-curve = { version = "0.12", features = [
 ] }
 generic-array = "0.14"
 rand_core = { version = "0.6", default-features = false }
-serde_ = { version = "1", package = "serde", default-features = false, features = [
+serde = { version = "1", default-features = false, features = [
   "derive",
 ], optional = true }
 sha2 = { version = "0.10", default-features = false, optional = true }

--- a/src/common.rs
+++ b/src/common.rs
@@ -72,7 +72,7 @@ impl Mode {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct BlindedElement<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -89,7 +89,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct EvaluationElement<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -106,7 +106,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct PreparedEvaluationElement<CS: CipherSuite>(pub(crate) EvaluationElement<CS>)
 where
@@ -120,7 +120,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct Proof<CS: CipherSuite>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,9 +555,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "serde")]
-extern crate serde_ as serde;
-
 mod ciphersuite;
 mod common;
 mod error;

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -41,7 +41,7 @@ use crate::{CipherSuite, Error, Group, Result};
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct OprfClient<CS: CipherSuite>
 where
@@ -59,7 +59,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct OprfServer<CS: CipherSuite>
 where

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -41,7 +41,7 @@ use crate::{CipherSuite, Error, Group, Result};
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct PoprfClient<CS: CipherSuite>
 where
@@ -61,7 +61,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct PoprfServer<CS: CipherSuite>
 where
@@ -541,7 +541,7 @@ pub type PoprfServerBatchEvaluatePreparedEvaluationElements<CS, I> = Map<
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct PoprfPreparedTweak<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -39,7 +39,7 @@ use crate::{CipherSuite, Error, Group, Result};
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct VoprfClient<CS: CipherSuite>
 where
@@ -59,7 +59,7 @@ where
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde", bound = "")
+    serde(bound = "")
 )]
 pub struct VoprfServer<CS: CipherSuite>
 where


### PR DESCRIPTION
Since we are now using Rust 1.60, we can use explicit crate features.
Rust-Analyzer had some serious issues with that `extern crate serde_ as serde`.
This also removes all implicit features, which is an improvement for users.