### PR TITLE
Update RustCrypto dependencies to v0.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           - --features serde
         toolchain:
           - stable
-          - 1.61.0
+          - 1.65.0
     name: test
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "voprf"
 readme = "README.md"
 repository = "https://github.com/novifinancial/voprf/"
-rust-version = "1.61"
+rust-version = "1.65"
 version = "0.5.0-pre.2"
 
 [features]
@@ -28,7 +28,7 @@ curve25519-dalek = { version = "=4.0.0-rc.1", default-features = false, features
 derive-where = { version = "1", features = ["zeroize-on-drop"] }
 digest = "0.10"
 displaydoc = { version = "0.2", default-features = false }
-elliptic-curve = { version = "=0.13.0-pre.5", features = [
+elliptic-curve = { version = "0.13", features = [
   "hash2curve",
   "sec1",
   "voprf",
@@ -45,11 +45,11 @@ zeroize = { version = "1.5", default-features = false }
 [dev-dependencies]
 generic-array = { version = "0.14", features = ["more_lengths"] }
 hex = "0.4"
-p256 = { version = "=0.13.0-pre", default-features = false, features = [
+p256 = { version = "0.13", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
-p384 = { version = "=0.13.0-pre", default-features = false, features = [
+p384 = { version = "0.13", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
@@ -63,7 +63,3 @@ sha2 = "0.10"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 targets = []
-
-[patch.crates-io]
-p256 = { git = "https://github.com/RustCrypto/elliptic-curves", rev = "136fed7944d53c0508b1a93cd97bdab46891bcf7" }
-p384 = { git = "https://github.com/RustCrypto/elliptic-curves", rev = "136fed7944d53c0508b1a93cd97bdab46891bcf7" }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ voprf = "0.5.0-pre.2"
 
 ### Minimum Supported Rust Version
 
-Rust **1.61** or higher.
+Rust **1.65** or higher.
 
 Contributors
 ------------


### PR DESCRIPTION
:rocket: :tada:

I think we should make a another pre-release and do a proper release after https://github.com/dalek-cryptography/curve25519-dalek/issues/405.

Replaces #105.