### PR TITLE
Bump `curve25519-dalek` to v4.0.0-rc.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = ["generic-array/serde", "dep:serde"]
 std = ["alloc"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0-rc.2", default-features = false, features = [
+curve25519-dalek = { version = "=4.0.0-rc.3", default-features = false, features = [
   "rand_core",
   "zeroize",
 ], optional = true }


### PR DESCRIPTION
Nothing significant changed for `voprf`.