### PR TITLE
Fix to deserialize uncompressed points

### DIFF
--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -293,9 +293,10 @@ where
 }
 
 fn deserialize_elem<G: Group>(input: &mut &[u8]) -> Result<G::Elem> {
-    let input = input
-        .take_ext(G::ElemLen::USIZE)
-        .ok_or(Error::Deserialization)?;
+  // This doesn't work with uncompressed points
+    // let input = input
+    //     .take_ext(G::ElemLen::USIZE)
+    //     .ok_or(Error::Deserialization)?;
     G::deserialize_elem(input)
 }
 


### PR DESCRIPTION
`EvaluationElement::deserialize` doesn't work with uncompressed points for NIST family of curves (haven't tried other curves). Removing unnecessary truncation of sec-1 encoded points since sec-1 deserializer already does all the appropriate sanity checks.