### PR TITLE
Test P-521

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ p384 = { version = "0.13", default-features = false, features = [
   "hash2curve",
   "voprf",
 ] }
+p521 = { version = "0.13.3", default-features = false, features = [
+  "hash2curve",
+  "voprf",
+] }
 proptest = "1"
 rand = "0.8"
 regex = "1"

--- a/src/group/tests.rs
+++ b/src/group/tests.rs
@@ -17,6 +17,7 @@ use crate::{Error, Group, Result};
 fn test_group_properties() -> Result<()> {
     use p256::NistP256;
     use p384::NistP384;
+    use p521::NistP521;
 
     #[cfg(feature = "ristretto255")]
     {
@@ -31,6 +32,9 @@ fn test_group_properties() -> Result<()> {
 
     test_identity_element_error::<NistP384>()?;
     test_zero_scalar_error::<NistP384>()?;
+
+    test_identity_element_error::<NistP521>()?;
+    test_zero_scalar_error::<NistP521>()?;
 
     Ok(())
 }

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -427,6 +427,7 @@ mod tests {
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
         use p384::NistP384;
+        use p521::NistP521;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -453,6 +454,13 @@ mod tests {
 
         zeroize_oprf_client::<NistP384>();
         zeroize_oprf_server::<NistP384>();
+
+        base_retrieval::<NistP521>();
+        base_inversion_unsalted::<NistP521>();
+        server_evaluate::<NistP521>();
+
+        zeroize_oprf_client::<NistP521>();
+        zeroize_oprf_server::<NistP521>();
 
         Ok(())
     }

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -967,6 +967,7 @@ mod tests {
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
         use p384::NistP384;
+        use p521::NistP521;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -993,6 +994,13 @@ mod tests {
 
         zeroize_verifiable_client::<NistP384>();
         zeroize_verifiable_server::<NistP384>();
+
+        verifiable_retrieval::<NistP521>();
+        verifiable_bad_public_key::<NistP521>();
+        verifiable_server_evaluate::<NistP521>();
+
+        zeroize_verifiable_client::<NistP521>();
+        zeroize_verifiable_server::<NistP521>();
 
         Ok(())
     }

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -391,6 +391,7 @@ mod test {
 
             let _ = $item::<p256::NistP256>::deserialize(&$bytes[..]);
             let _ = $item::<p384::NistP384>::deserialize(&$bytes[..]);
+            let _ = $item::<p521::NistP521>::deserialize(&$bytes[..]);
         };
     }
 

--- a/src/tests/test_cfrg_vectors.rs
+++ b/src/tests/test_cfrg_vectors.rs
@@ -89,6 +89,7 @@ macro_rules! json_to_test_vectors {
 fn test_vectors() -> Result<()> {
     use p256::NistP256;
     use p384::NistP384;
+    use p521::NistP521;
 
     let rfc: Value = serde_json::from_str(rfc_to_json(super::cfrg_vectors::VECTORS).as_str())
         .expect("Could not parse json");
@@ -187,6 +188,33 @@ fn test_vectors() -> Result<()> {
     test_poprf_blind_evaluate::<NistP384>(&p384_poprf_tvs)?;
     test_poprf_finalize::<NistP384>(&p384_poprf_tvs)?;
     test_poprf_evaluate::<NistP384>(&p384_poprf_tvs)?;
+
+    let p521_oprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P521-SHA512"), String::from("OPRF"));
+    assert_ne!(p521_oprf_tvs.len(), 0);
+    test_oprf_seed_to_key::<NistP521>(&p521_oprf_tvs)?;
+    test_oprf_blind::<NistP521>(&p521_oprf_tvs)?;
+    test_oprf_blind_evaluate::<NistP521>(&p521_oprf_tvs)?;
+    test_oprf_finalize::<NistP521>(&p521_oprf_tvs)?;
+    test_oprf_evaluate::<NistP521>(&p521_oprf_tvs)?;
+
+    let p521_voprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P521-SHA512"), String::from("VOPRF"));
+    assert_ne!(p521_voprf_tvs.len(), 0);
+    test_voprf_seed_to_key::<NistP521>(&p521_voprf_tvs)?;
+    test_voprf_blind::<NistP521>(&p521_voprf_tvs)?;
+    test_voprf_blind_evaluate::<NistP521>(&p521_voprf_tvs)?;
+    test_voprf_finalize::<NistP521>(&p521_voprf_tvs)?;
+    test_voprf_evaluate::<NistP521>(&p521_voprf_tvs)?;
+
+    let p521_poprf_tvs =
+        json_to_test_vectors!(rfc, String::from("P521-SHA512"), String::from("POPRF"));
+    assert_ne!(p521_poprf_tvs.len(), 0);
+    test_poprf_seed_to_key::<NistP521>(&p521_poprf_tvs)?;
+    test_poprf_blind::<NistP521>(&p521_poprf_tvs)?;
+    test_poprf_blind_evaluate::<NistP521>(&p521_poprf_tvs)?;
+    test_poprf_finalize::<NistP521>(&p521_poprf_tvs)?;
+    test_poprf_evaluate::<NistP521>(&p521_poprf_tvs)?;
 
     Ok(())
 }

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -836,6 +836,7 @@ mod tests {
     fn test_functionality() -> Result<()> {
         use p256::NistP256;
         use p384::NistP384;
+        use p521::NistP521;
 
         #[cfg(feature = "ristretto255")]
         {
@@ -868,6 +869,15 @@ mod tests {
 
         zeroize_voprf_client::<NistP384>();
         zeroize_voprf_server::<NistP384>();
+
+        verifiable_retrieval::<NistP521>();
+        verifiable_batch_retrieval::<NistP521>();
+        verifiable_bad_public_key::<NistP521>();
+        verifiable_batch_bad_public_key::<NistP521>();
+        verifiable_server_evaluate::<NistP521>();
+
+        zeroize_voprf_client::<NistP521>();
+        zeroize_voprf_server::<NistP521>();
 
         Ok(())
     }


### PR DESCRIPTION
This adds testing of P-521 through the [`p521`](https://crates.io/crates/p521) crate.

Still requires:
- [x] https://github.com/RustCrypto/elliptic-curves/pull/964
- [x] https://github.com/RustCrypto/elliptic-curves/issues/965

See #84 for a previously similar addition.
See https://github.com/facebook/opaque-ke/pull/349 for the same PR in `opaque-ke`, which doesn't rely on this PR.