### PR TITLE
Bump MSRV to v1.83

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           - --features serde
         toolchain:
           - stable
-          - 1.65.0
+          - 1.83.0
     name: test
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "voprf"
 readme = "README.md"
 repository = "https://github.com/facebook/voprf/"
-rust-version = "1.65"
+rust-version = "1.83"
 version = "0.5.0"
 
 [features]

--- a/src/common.rs
+++ b/src/common.rs
@@ -147,8 +147,8 @@ pub(crate) fn generate_proof<CS: CipherSuite, R: RngCore + CryptoRng>(
     k: <CS::Group as Group>::Scalar,
     a: <CS::Group as Group>::Elem,
     b: <CS::Group as Group>::Elem,
-    cs: impl Iterator<Item = <CS::Group as Group>::Elem> + ExactSizeIterator,
-    ds: impl Iterator<Item = <CS::Group as Group>::Elem> + ExactSizeIterator,
+    cs: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
+    ds: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
     mode: Mode,
 ) -> Result<Proof<CS>>
 where
@@ -209,8 +209,8 @@ where
 pub(crate) fn verify_proof<CS: CipherSuite>(
     a: <CS::Group as Group>::Elem,
     b: <CS::Group as Group>::Elem,
-    cs: impl Iterator<Item = <CS::Group as Group>::Elem> + ExactSizeIterator,
-    ds: impl Iterator<Item = <CS::Group as Group>::Elem> + ExactSizeIterator,
+    cs: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
+    ds: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
     proof: &Proof<CS>,
     mode: Mode,
 ) -> Result<()>

--- a/src/common.rs
+++ b/src/common.rs
@@ -12,10 +12,9 @@ use core::convert::TryFrom;
 use core::ops::Add;
 
 use derive_where::derive_where;
-use digest::core_api::BlockSizeUser;
-use digest::{Digest, Output, OutputSizeUser};
+use digest::{Digest, Output};
 use generic_array::sequence::Concat;
-use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U2, U256, U9};
+use generic_array::typenum::{IsLess, Unsigned, U2, U256, U9};
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 use subtle::ConstantTimeEq;
@@ -79,10 +78,7 @@ impl Mode {
 pub struct BlindedElement<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
     pub(crate)  <CS::Group as Group>::Elem,
-)
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+);
 
 /// The server's response to the [BlindedElement] message from a client (either
 /// verifiable or not) to a server (either verifiable or not).
@@ -96,10 +92,7 @@ where
 pub struct EvaluationElement<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
     pub(crate)  <CS::Group as Group>::Elem,
-)
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+);
 
 /// Contains prepared [`EvaluationElement`]s by a server batch evaluate
 /// preparation.
@@ -110,10 +103,7 @@ where
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct PreparedEvaluationElement<CS: CipherSuite>(pub(crate) EvaluationElement<CS>)
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+pub struct PreparedEvaluationElement<CS: CipherSuite>(pub(crate) EvaluationElement<CS>);
 
 /// A proof produced by a server that the OPRF output matches against a server
 /// public key.
@@ -124,11 +114,7 @@ where
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct Proof<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct Proof<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) c_scalar: <CS::Group as Group>::Scalar,
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
@@ -150,11 +136,7 @@ pub(crate) fn generate_proof<CS: CipherSuite, R: RngCore + CryptoRng>(
     cs: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
     ds: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
     mode: Mode,
-) -> Result<Proof<CS>>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<Proof<CS>> {
     // https://www.rfc-editor.org/rfc/rfc9497#section-2.2.1
 
     let (m, z) = compute_composites::<CS, _, _>(Some(k), b, cs, ds, mode)?;
@@ -213,11 +195,7 @@ pub(crate) fn verify_proof<CS: CipherSuite>(
     ds: impl ExactSizeIterator<Item = <CS::Group as Group>::Elem>,
     proof: &Proof<CS>,
     mode: Mode,
-) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<()> {
     // https://www.rfc-editor.org/rfc/rfc9497#section-2.2.2
     let (m, z) = compute_composites::<CS, _, _>(None, b, cs, ds, mode)?;
     let t2 = (a * &proof.s_scalar) + &(b * &proof.c_scalar);
@@ -282,11 +260,7 @@ fn compute_composites<
     c_slice: IC,
     d_slice: ID,
     mode: Mode,
-) -> Result<ComputeCompositesResult<CS>>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<ComputeCompositesResult<CS>> {
     // https://www.rfc-editor.org/rfc/rfc9497#section-2.2.1
 
     let elem_len = <CS::Group as Group>::ElemLen::U16.to_be_bytes();
@@ -362,11 +336,7 @@ pub(crate) fn derive_key_internal<CS: CipherSuite>(
     seed: &[u8],
     info: &[u8],
     mode: Mode,
-) -> Result<<CS::Group as Group>::Scalar, Error>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Scalar, Error> {
     let dst = Dst::new::<CS, _, _>(STR_DERIVE_KEYPAIR, mode);
 
     let info_len = i2osp_2(info.len()).map_err(|_| Error::DeriveKeyPair)?;
@@ -400,11 +370,7 @@ pub fn derive_key<CS: CipherSuite>(
     seed: &[u8],
     info: &[u8],
     mode: Mode,
-) -> Result<<CS::Group as Group>::Scalar, Error>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Scalar, Error> {
     derive_key_internal::<CS>(seed, info, mode)
 }
 
@@ -418,11 +384,7 @@ pub(crate) fn derive_keypair<CS: CipherSuite>(
     seed: &[u8],
     info: &[u8],
     mode: Mode,
-) -> Result<DeriveKeypairResult<CS>, Error>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<DeriveKeypairResult<CS>, Error> {
     let sk_s = derive_key_internal::<CS>(seed, info, mode)?;
     let pk_s = CS::Group::base_elem() * &sk_s;
 
@@ -438,11 +400,7 @@ pub(crate) fn deterministic_blind_unchecked<CS: CipherSuite>(
     input: &[u8],
     blind: &<CS::Group as Group>::Scalar,
     mode: Mode,
-) -> Result<<CS::Group as Group>::Elem>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Elem> {
     let hashed_point = hash_to_group::<CS>(input, mode)?;
     Ok(hashed_point * blind)
 }
@@ -451,11 +409,7 @@ where
 pub(crate) fn hash_to_group<CS: CipherSuite>(
     input: &[u8],
     mode: Mode,
-) -> Result<<CS::Group as Group>::Elem>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Elem> {
     let dst = Dst::new::<CS, _, _>(STR_HASH_TO_GROUP, mode);
     CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst.as_dst()).map_err(|_| Error::Input)
 }
@@ -466,11 +420,7 @@ pub(crate) fn server_evaluate_hash_input<CS: CipherSuite>(
     input: &[u8],
     info: Option<&[u8]>,
     issued_element: GenericArray<u8, <<CS as CipherSuite>::Group as Group>::ElemLen>,
-) -> Result<Output<CS::Hash>>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<Output<CS::Hash>> {
     // OPRF & VOPRF
     // hashInput = I2OSP(len(input), 2) || input ||
     //             I2OSP(len(issuedElement), 2) || issuedElement ||
@@ -504,12 +454,11 @@ pub(crate) struct Dst<L: ArrayLength<u8>> {
 }
 
 impl<L: ArrayLength<u8>> Dst<L> {
-    pub(crate) fn new<CS: CipherSuite, T, TL: ArrayLength<u8>>(par_1: T, mode: Mode) -> Self
+    pub(crate) fn new<CS, T, TL>(par_1: T, mode: Mode) -> Self
     where
+        CS: CipherSuite,
         T: Into<GenericArray<u8, TL>>,
-        TL: Add<U9, Output = L>,
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
+        TL: ArrayLength<u8> + Add<U9, Output = L>,
     {
         let par_1 = par_1.into();
         // Generates the contextString parameter as defined in

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,5 +41,4 @@ pub enum InternalError {
     I2osp,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/src/group/mod.rs
+++ b/src/group/mod.rs
@@ -16,7 +16,7 @@ use core::ops::{Add, Mul, Sub};
 
 use digest::core_api::BlockSizeUser;
 use digest::{FixedOutput, HashMarker};
-use generic_array::typenum::{IsLess, IsLessOrEqual, U256};
+use generic_array::typenum::{IsLess, IsLessOrEqual, Sum, U256};
 use generic_array::{ArrayLength, GenericArray};
 use rand_core::{CryptoRng, RngCore};
 #[cfg(feature = "ristretto255")]
@@ -28,7 +28,15 @@ use crate::{InternalError, Result};
 
 /// A prime-order subgroup of a base field (EC, prime-order field ...). This
 /// subgroup is noted additively — as in the RFC — in this trait.
-pub trait Group {
+pub trait Group
+where
+    // `VoprfClientLen`, `PoprfClientLen`, `VoprfServerLen`, `PoprfServerLen`
+    Self::ScalarLen: Add<Self::ElemLen>,
+    Sum<Self::ScalarLen, Self::ElemLen>: ArrayLength<u8>,
+    // `ProofLen`
+    Self::ScalarLen: Add<Self::ScalarLen>,
+    Sum<Self::ScalarLen, Self::ScalarLen>: ArrayLength<u8>,
+{
     /// The type of group elements
     type Elem: ConstantTimeEq
         + Copy

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -194,7 +194,7 @@ where
         Ok(Self { sk })
     }
 
-    // Only used for tests
+    /// Only used for tests
     #[cfg(test)]
     pub fn get_private_key(&self) -> <CS::Group as Group>::Scalar {
         self.sk
@@ -261,7 +261,7 @@ fn finalize_after_unblind<
 >(
     inputs_and_unblinded_elements: IE,
     _unused: &'a [u8],
-) -> FinalizeAfterUnblindResult<CS, I, IE>
+) -> FinalizeAfterUnblindResult<'a, CS, I, IE>
 where
     <CS::Hash as OutputSizeUser>::OutputSize:
         IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,

--- a/src/oprf.rs
+++ b/src/oprf.rs
@@ -11,9 +11,8 @@
 use core::iter::{self, Map};
 
 use derive_where::derive_where;
-use digest::core_api::BlockSizeUser;
-use digest::{Digest, Output, OutputSizeUser};
-use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
+use digest::{Digest, Output};
+use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
@@ -44,11 +43,7 @@ use crate::{CipherSuite, Error, Group, Result};
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct OprfClient<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct OprfClient<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) blind: <CS::Group as Group>::Scalar,
 }
@@ -62,11 +57,7 @@ where
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct OprfServer<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct OprfServer<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) sk: <CS::Group as Group>::Scalar,
 }
@@ -76,11 +67,7 @@ where
 // =================== //
 /////////////////////////
 
-impl<CS: CipherSuite> OprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> OprfClient<CS> {
     /// Computes the first step for the multiplicative blinding version of
     /// DH-OPRF.
     ///
@@ -154,11 +141,7 @@ where
     }
 }
 
-impl<CS: CipherSuite> OprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> OprfServer<CS> {
     /// Produces a new instance of a [OprfServer] using a supplied RNG
     ///
     /// # Errors
@@ -231,11 +214,7 @@ where
 
 /// Contains the fields that are returned by a non-verifiable client blind
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
-pub struct OprfClientBlindResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct OprfClientBlindResult<CS: CipherSuite> {
     /// The state to be persisted on the client
     pub state: OprfClient<CS>,
     /// The message to send to the server
@@ -261,11 +240,7 @@ fn finalize_after_unblind<
 >(
     inputs_and_unblinded_elements: IE,
     _unused: &'a [u8],
-) -> FinalizeAfterUnblindResult<'a, CS, I, IE>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> FinalizeAfterUnblindResult<'a, CS, I, IE> {
     inputs_and_unblinded_elements.map(|(input, unblinded_element)| {
         let elem_len = <CS::Group as Group>::ElemLen::U16.to_be_bytes();
 
@@ -303,11 +278,7 @@ mod tests {
         key: <CS::Group as Group>::Scalar,
         info: &[u8],
         mode: Mode,
-    ) -> Output<CS::Hash>
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    ) -> Output<CS::Hash> {
         let dst = Dst::new::<CS, _, _>(STR_HASH_TO_GROUP, mode);
         let point = CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst.as_dst()).unwrap();
 
@@ -319,11 +290,7 @@ mod tests {
             .unwrap()
     }
 
-    fn base_retrieval<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn base_retrieval<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = OprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -334,11 +301,7 @@ mod tests {
         assert_eq!(client_finalize_result, res2);
     }
 
-    fn base_inversion_unsalted<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn base_inversion_unsalted<CS: CipherSuite>() {
         let mut rng = OsRng;
         let mut input = [0u8; 64];
         rng.fill_bytes(&mut input);
@@ -358,11 +321,7 @@ mod tests {
         assert_eq!(client_finalize_result, res2);
     }
 
-    fn server_evaluate<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn server_evaluate<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = OprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -386,11 +345,7 @@ mod tests {
         assert!(client_finalize != server_evaluate);
     }
 
-    fn zeroize_oprf_client<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn zeroize_oprf_client<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = OprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -404,11 +359,7 @@ mod tests {
         assert!(message.serialize().iter().all(|&x| x == 0));
     }
 
-    fn zeroize_oprf_server<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn zeroize_oprf_server<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = OprfClient::<CS>::blind(input, &mut rng).unwrap();

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -235,7 +235,7 @@ where
         Ok(Self { sk, pk })
     }
 
-    // Only used for tests
+    /// Only used for tests
     #[cfg(test)]
     pub fn get_private_key(&self) -> <CS::Group as Group>::Scalar {
         self.sk

--- a/src/poprf.rs
+++ b/src/poprf.rs
@@ -13,9 +13,8 @@ use alloc::vec::Vec;
 use core::iter::{self, Map, Repeat, Zip};
 
 use derive_where::derive_where;
-use digest::core_api::BlockSizeUser;
 use digest::{Digest, Output, OutputSizeUser};
-use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
+use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
@@ -42,11 +41,7 @@ use crate::{CipherSuite, Error, Group, Result};
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct PoprfClient<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfClient<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) blind: <CS::Group as Group>::Scalar,
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -62,11 +57,7 @@ where
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct PoprfServer<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfServer<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) sk: <CS::Group as Group>::Scalar,
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -78,11 +69,7 @@ where
 // =================== //
 /////////////////////////
 
-impl<CS: CipherSuite> PoprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> PoprfClient<CS> {
     /// Computes the first step for the multiplicative blinding version of
     /// DH-OPRF.
     ///
@@ -193,11 +180,7 @@ where
     }
 }
 
-impl<CS: CipherSuite> PoprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> PoprfServer<CS> {
     /// Produces a new instance of a [PoprfServer] using a supplied RNG
     ///
     /// # Errors
@@ -427,11 +410,7 @@ where
     }
 }
 
-impl<CS: CipherSuite> BlindedElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> BlindedElement<CS> {
     /// Creates a [BlindedElement] from a raw group element.
     ///
     /// # Caution
@@ -450,11 +429,7 @@ where
     }
 }
 
-impl<CS: CipherSuite> EvaluationElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> EvaluationElement<CS> {
     /// Creates an [EvaluationElement] from a raw group element.
     ///
     /// # Caution
@@ -480,11 +455,7 @@ where
 
 /// Contains the fields that are returned by a verifiable client blind
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
-pub struct PoprfClientBlindResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfClientBlindResult<CS: CipherSuite> {
     /// The state to be persisted on the client
     pub state: PoprfClient<CS>,
     /// The message to send to the server
@@ -497,11 +468,7 @@ pub type PoprfClientBatchFinalizeResult<'a, CS, II, IC, IM> =
 
 /// Contains the fields that are returned by a verifiable server evaluate
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
-pub struct PoprfServerEvaluateResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfServerEvaluateResult<CS: CipherSuite> {
     /// The message to send to the client
     pub message: EvaluationElement<CS>,
     /// The proof for the client to verify
@@ -511,11 +478,7 @@ where
 /// Contains the fields that are returned by a verifiable server batch evaluate
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
 #[cfg(feature = "alloc")]
-pub struct PoprfServerBatchEvaluateResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfServerBatchEvaluateResult<CS: CipherSuite> {
     /// The messages to send to the client
     pub messages: Vec<EvaluationElement<CS>>,
     /// The proof for the client to verify
@@ -545,19 +508,12 @@ pub type PoprfServerBatchEvaluatePreparedEvaluationElements<CS, I> = Map<
 pub struct PoprfPreparedTweak<CS: CipherSuite>(
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     <CS::Group as Group>::Scalar,
-)
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>;
+);
 
 /// Contains the fields that are returned by a partially verifiable server batch
 /// evaluate prepare
 #[derive_where(Debug; I, <CS::Group as Group>::Scalar)]
-pub struct PoprfServerBatchEvaluatePrepareResult<CS: CipherSuite, I>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct PoprfServerBatchEvaluatePrepareResult<CS: CipherSuite, I> {
     /// Prepared [`EvaluationElement`].
     pub prepared_evaluation_elements: PoprfServerBatchEvaluatePreparedEvaluationElements<CS, I>,
     /// Prepared tweak.
@@ -576,8 +532,6 @@ pub type PoprfServerBatchEvaluateFinishedMessages<'a, CS, I> = Map<
 #[derive_where(Debug; <&'a I as IntoIterator>::IntoIter, <CS::Group as Group>::Scalar)]
 pub struct PoprfServerBatchEvaluateFinishResult<'a, CS: 'a + CipherSuite, I>
 where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     &'a I: IntoIterator<Item = &'a PreparedEvaluationElement<CS>>,
 {
     /// The [`EvaluationElement`]s to send to the client
@@ -598,11 +552,7 @@ where
 fn compute_tweaked_key<CS: CipherSuite>(
     pk: <CS::Group as Group>::Elem,
     info: Option<&[u8]>,
-) -> Result<<CS::Group as Group>::Elem>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Elem> {
     // None for info is treated the same as empty bytes
     let info = info.unwrap_or_default();
 
@@ -636,11 +586,7 @@ where
 fn compute_tweak<CS: CipherSuite>(
     sk: <CS::Group as Group>::Scalar,
     info: Option<&[u8]>,
-) -> Result<<CS::Group as Group>::Scalar>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<<CS::Group as Group>::Scalar> {
     // None for info is treated the same as empty bytes
     let info = info.unwrap_or_default();
 
@@ -691,8 +637,6 @@ fn poprf_unblind<'a, CS: 'a + CipherSuite, IC, IM>(
     info: Option<&[u8]>,
 ) -> Result<PoprfUnblindResult<'a, CS, IC, IM>>
 where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     &'a IC: 'a + IntoIterator<Item = &'a PoprfClient<CS>>,
     <&'a IC as IntoIterator>::IntoIter: ExactSizeIterator,
     &'a IM: 'a + IntoIterator<Item = &'a EvaluationElement<CS>>,
@@ -742,11 +686,7 @@ fn finalize_after_unblind<
     unblinded_elements: IE,
     inputs: II,
     info: Option<&'a [u8]>,
-) -> Result<FinalizeAfterUnblindResult<'a, CS, IE, II>>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> Result<FinalizeAfterUnblindResult<'a, CS, IE, II>> {
     if unblinded_elements.len() != inputs.len() {
         return Err(Error::Batch);
     }
@@ -784,11 +724,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Add;
     use core::ptr;
 
-    use generic_array::typenum::Sum;
-    use generic_array::ArrayLength;
     use rand::rngs::OsRng;
 
     use super::*;
@@ -800,11 +737,7 @@ mod tests {
         key: <CS::Group as Group>::Scalar,
         info: &[u8],
         mode: Mode,
-    ) -> Output<CS::Hash>
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    ) -> Output<CS::Hash> {
         let t = compute_tweak::<CS>(key, Some(info)).unwrap();
 
         let dst = Dst::new::<CS, _, _>(STR_HASH_TO_GROUP, mode);
@@ -820,11 +753,7 @@ mod tests {
             .unwrap()
     }
 
-    fn verifiable_retrieval<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_retrieval<CS: CipherSuite>() {
         let input = b"input";
         let info = b"info";
         let mut rng = OsRng;
@@ -847,11 +776,7 @@ mod tests {
         assert_eq!(client_finalize_result, res2);
     }
 
-    fn verifiable_bad_public_key<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_bad_public_key<CS: CipherSuite>() {
         let input = b"input";
         let info = b"info";
         let mut rng = OsRng;
@@ -875,11 +800,7 @@ mod tests {
         assert!(client_finalize_result.is_err());
     }
 
-    fn verifiable_server_evaluate<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_server_evaluate<CS: CipherSuite>() {
         let input = b"input";
         let info = Some(b"info".as_slice());
         let mut rng = OsRng;
@@ -912,13 +833,7 @@ mod tests {
         assert!(client_finalize != server_evaluate);
     }
 
-    fn zeroize_verifiable_client<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ElemLen>: ArrayLength<u8>,
-    {
+    fn zeroize_verifiable_client<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = PoprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -932,15 +847,7 @@ mod tests {
         assert!(message.serialize().iter().all(|&x| x == 0));
     }
 
-    fn zeroize_verifiable_server<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ElemLen>: ArrayLength<u8>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ScalarLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ScalarLen>: ArrayLength<u8>,
-    {
+    fn zeroize_verifiable_server<CS: CipherSuite>() {
         let input = b"input";
         let info = b"info";
         let mut rng = OsRng;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -9,13 +9,9 @@
 //! Handles the serialization of each of the components used in the VOPRF
 //! protocol
 
-use core::ops::Add;
-
-use digest::core_api::BlockSizeUser;
-use digest::OutputSizeUser;
 use generic_array::sequence::Concat;
-use generic_array::typenum::{IsLess, IsLessOrEqual, Sum, Unsigned, U256};
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::typenum::{Sum, Unsigned};
+use generic_array::GenericArray;
 
 use crate::{
     BlindedElement, CipherSuite, Error, EvaluationElement, Group, OprfClient, OprfServer,
@@ -30,11 +26,7 @@ use crate::{
 /// Length of [`OprfClient`] in bytes for serialization.
 pub type OprfClientLen<CS> = <<CS as CipherSuite>::Group as Group>::ScalarLen;
 
-impl<CS: CipherSuite> OprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> OprfClient<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, OprfClientLen<CS>> {
         CS::Group::serialize_scalar(self.blind)
@@ -57,17 +49,9 @@ pub type VoprfClientLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ElemLen,
 >;
 
-impl<CS: CipherSuite> VoprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> VoprfClient<CS> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, VoprfClientLen<CS>>
-    where
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        VoprfClientLen<CS>: ArrayLength<u8>,
-    {
+    pub fn serialize(&self) -> GenericArray<u8, VoprfClientLen<CS>> {
         <CS::Group as Group>::serialize_scalar(self.blind)
             .concat(<CS::Group as Group>::serialize_elem(self.blinded_element))
     }
@@ -93,17 +77,9 @@ pub type PoprfClientLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ElemLen,
 >;
 
-impl<CS: CipherSuite> PoprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> PoprfClient<CS> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, PoprfClientLen<CS>>
-    where
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        PoprfClientLen<CS>: ArrayLength<u8>,
-    {
+    pub fn serialize(&self) -> GenericArray<u8, PoprfClientLen<CS>> {
         <CS::Group as Group>::serialize_scalar(self.blind)
             .concat(<CS::Group as Group>::serialize_elem(self.blinded_element))
     }
@@ -126,11 +102,7 @@ where
 /// Length of [`OprfServer`] in bytes for serialization.
 pub type OprfServerLen<CS> = <<CS as CipherSuite>::Group as Group>::ScalarLen;
 
-impl<CS: CipherSuite> OprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> OprfServer<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, OprfServerLen<CS>> {
         CS::Group::serialize_scalar(self.sk)
@@ -153,17 +125,9 @@ pub type VoprfServerLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ElemLen,
 >;
 
-impl<CS: CipherSuite> VoprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> VoprfServer<CS> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, VoprfServerLen<CS>>
-    where
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        VoprfServerLen<CS>: ArrayLength<u8>,
-    {
+    pub fn serialize(&self) -> GenericArray<u8, VoprfServerLen<CS>> {
         CS::Group::serialize_scalar(self.sk).concat(CS::Group::serialize_elem(self.pk))
     }
 
@@ -185,17 +149,9 @@ pub type PoprfServerLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ElemLen,
 >;
 
-impl<CS: CipherSuite> PoprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> PoprfServer<CS> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, PoprfServerLen<CS>>
-    where
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        PoprfServerLen<CS>: ArrayLength<u8>,
-    {
+    pub fn serialize(&self) -> GenericArray<u8, PoprfServerLen<CS>> {
         CS::Group::serialize_scalar(self.sk).concat(CS::Group::serialize_elem(self.pk))
     }
 
@@ -217,17 +173,9 @@ pub type ProofLen<CS> = Sum<
     <<CS as CipherSuite>::Group as Group>::ScalarLen,
 >;
 
-impl<CS: CipherSuite> Proof<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> Proof<CS> {
     /// Serialization into bytes
-    pub fn serialize(&self) -> GenericArray<u8, ProofLen<CS>>
-    where
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ScalarLen>,
-        ProofLen<CS>: ArrayLength<u8>,
-    {
+    pub fn serialize(&self) -> GenericArray<u8, ProofLen<CS>> {
         CS::Group::serialize_scalar(self.c_scalar)
             .concat(CS::Group::serialize_scalar(self.s_scalar))
     }
@@ -247,11 +195,7 @@ where
 /// Length of [`BlindedElement`] in bytes for serialization.
 pub type BlindedElementLen<CS> = <<CS as CipherSuite>::Group as Group>::ElemLen;
 
-impl<CS: CipherSuite> BlindedElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> BlindedElement<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, BlindedElementLen<CS>> {
         CS::Group::serialize_elem(self.0)
@@ -271,11 +215,7 @@ where
 /// Length of [`EvaluationElement`] in bytes for serialization.
 pub type EvaluationElementLen<CS> = <<CS as CipherSuite>::Group as Group>::ElemLen;
 
-impl<CS: CipherSuite> EvaluationElement<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> EvaluationElement<CS> {
     /// Serialization into bytes
     pub fn serialize(&self) -> GenericArray<u8, EvaluationElementLen<CS>> {
         CS::Group::serialize_elem(self.0)

--- a/src/tests/test_cfrg_vectors.rs
+++ b/src/tests/test_cfrg_vectors.rs
@@ -9,12 +9,7 @@
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::ops::Add;
 
-use digest::core_api::BlockSizeUser;
-use digest::OutputSizeUser;
-use generic_array::typenum::{IsLess, IsLessOrEqual, Sum, U256};
-use generic_array::ArrayLength;
 use serde_json::Value;
 
 use crate::tests::mock_rng::CycleRng;
@@ -219,11 +214,7 @@ fn test_vectors() -> Result<()> {
     Ok(())
 }
 
-fn test_oprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_oprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let server = OprfServer::<CS>::new_from_seed(&parameters.seed, &parameters.key_info)?;
 
@@ -235,11 +226,7 @@ where
     Ok(())
 }
 
-fn test_voprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_voprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let server = VoprfServer::<CS>::new_from_seed(&parameters.seed, &parameters.key_info)?;
 
@@ -255,11 +242,7 @@ where
     Ok(())
 }
 
-fn test_poprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_poprf_seed_to_key<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let server = PoprfServer::<CS>::new_from_seed(&parameters.seed, &parameters.key_info)?;
 
@@ -276,11 +259,7 @@ where
 }
 
 // Tests input -> blind, blinded_element
-fn test_oprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_oprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind = CS::Group::deserialize_scalar(&parameters.blind[i])?;
@@ -301,11 +280,7 @@ where
 }
 
 // Tests input -> blind, blinded_element
-fn test_voprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_voprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind = CS::Group::deserialize_scalar(&parameters.blind[i])?;
@@ -326,11 +301,7 @@ where
 }
 
 // Tests input -> blind, blinded_element
-fn test_poprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_poprf_blind<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let blind = CS::Group::deserialize_scalar(&parameters.blind[i])?;
@@ -351,11 +322,7 @@ where
 }
 
 // Tests sksm, blinded_element -> evaluation_element
-fn test_oprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_oprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = OprfServer::<CS>::new_with_key(&parameters.sksm)?;
@@ -372,13 +339,7 @@ where
     Ok(())
 }
 
-fn test_voprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ScalarLen>,
-    Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ScalarLen>: ArrayLength<u8>,
-{
+fn test_voprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let mut rng = CycleRng::new(parameters.proof_random_scalar.clone());
         let server = VoprfServer::<CS>::new_with_key(&parameters.sksm)?;
@@ -404,13 +365,7 @@ where
     Ok(())
 }
 
-fn test_poprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ScalarLen>,
-    Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ScalarLen>: ArrayLength<u8>,
-{
+fn test_poprf_blind_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let mut rng = CycleRng::new(parameters.proof_random_scalar.clone());
         let server = PoprfServer::<CS>::new_with_key(&parameters.sksm)?;
@@ -446,11 +401,7 @@ where
 }
 
 // Tests input, blind, evaluation_element -> output
-fn test_oprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_oprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let client =
@@ -467,11 +418,7 @@ where
     Ok(())
 }
 
-fn test_voprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_voprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
@@ -506,11 +453,7 @@ where
     Ok(())
 }
 
-fn test_poprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_poprf_finalize<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         let mut clients = vec![];
         for i in 0..parameters.input.len() {
@@ -544,11 +487,7 @@ where
 }
 
 // Tests input, sksm -> output
-fn test_oprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_oprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = OprfServer::<CS>::new_with_key(&parameters.sksm)?;
@@ -561,11 +500,7 @@ where
     Ok(())
 }
 
-fn test_voprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_voprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = VoprfServer::<CS>::new_with_key(&parameters.sksm)?;
@@ -578,11 +513,7 @@ where
     Ok(())
 }
 
-fn test_poprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+fn test_poprf_evaluate<CS: CipherSuite>(tvs: &[VOPRFTestVectorParameters]) -> Result<()> {
     for parameters in tvs {
         for i in 0..parameters.input.len() {
             let server = PoprfServer::<CS>::new_with_key(&parameters.sksm)?;

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -161,7 +161,7 @@ where
     ///
     /// The resulting messages can each fail individually with [`Error::Input`]
     /// if the `input` is empty or longer then [`u16::MAX`].
-    pub fn batch_finalize<'a, I: 'a, II, IC, IM>(
+    pub fn batch_finalize<'a, I, II, IC, IM>(
         inputs: &'a II,
         clients: &'a IC,
         messages: &'a IM,
@@ -170,7 +170,7 @@ where
     ) -> Result<VoprfClientBatchFinalizeResult<'a, CS, I, II, IC, IM>>
     where
         CS: 'a,
-        I: AsRef<[u8]>,
+        I: 'a + AsRef<[u8]>,
         &'a II: 'a + IntoIterator<Item = I>,
         <&'a II as IntoIterator>::IntoIter: ExactSizeIterator,
         &'a IC: 'a + IntoIterator<Item = &'a VoprfClient<CS>>,
@@ -197,7 +197,7 @@ where
         }
     }
 
-    // Only used for test functions
+    /// Only used for test functions
     #[cfg(test)]
     pub fn get_blind(&self) -> <CS::Group as Group>::Scalar {
         self.blind
@@ -246,7 +246,7 @@ where
         Ok(Self { sk, pk })
     }
 
-    // Only used for tests
+    /// Only used for tests
     #[cfg(test)]
     pub fn get_private_key(&self) -> <CS::Group as Group>::Scalar {
         self.sk

--- a/src/voprf.rs
+++ b/src/voprf.rs
@@ -13,9 +13,8 @@ use alloc::vec::Vec;
 use core::iter::{self, Map, Repeat, Zip};
 
 use derive_where::derive_where;
-use digest::core_api::BlockSizeUser;
-use digest::{Digest, Output, OutputSizeUser};
-use generic_array::typenum::{IsLess, IsLessOrEqual, Unsigned, U256};
+use digest::{Digest, Output};
+use generic_array::typenum::Unsigned;
 use generic_array::GenericArray;
 use rand_core::{CryptoRng, RngCore};
 
@@ -42,11 +41,7 @@ use crate::{CipherSuite, Error, Group, Result};
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct VoprfClient<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct VoprfClient<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) blind: <CS::Group as Group>::Scalar,
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -62,11 +57,7 @@ where
     derive(serde::Deserialize, serde::Serialize),
     serde(bound = "")
 )]
-pub struct VoprfServer<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct VoprfServer<CS: CipherSuite> {
     #[cfg_attr(feature = "serde", serde(with = "Scalar::<CS::Group>"))]
     pub(crate) sk: <CS::Group as Group>::Scalar,
     #[cfg_attr(feature = "serde", serde(with = "Element::<CS::Group>"))]
@@ -78,11 +69,7 @@ where
 // =================== //
 /////////////////////////
 
-impl<CS: CipherSuite> VoprfClient<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> VoprfClient<CS> {
     /// Computes the first step for the multiplicative blinding version of
     /// DH-OPRF.
     ///
@@ -204,11 +191,7 @@ where
     }
 }
 
-impl<CS: CipherSuite> VoprfServer<CS>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+impl<CS: CipherSuite> VoprfServer<CS> {
     /// Produces a new instance of a [VoprfServer] using a supplied RNG
     ///
     /// # Errors
@@ -402,11 +385,7 @@ where
 
 /// Contains the fields that are returned by a verifiable client blind
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
-pub struct VoprfClientBlindResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct VoprfClientBlindResult<CS: CipherSuite> {
     /// The state to be persisted on the client
     pub state: VoprfClient<CS>,
     /// The message to send to the server
@@ -423,11 +402,7 @@ pub type VoprfClientBatchFinalizeResult<'a, C, I, II, IC, IM> = FinalizeAfterUnb
 
 /// Contains the fields that are returned by a verifiable server evaluate
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
-pub struct VoprfServerEvaluateResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct VoprfServerEvaluateResult<CS: CipherSuite> {
     /// The message to send to the client
     pub message: EvaluationElement<CS>,
     /// The proof for the client to verify
@@ -437,11 +412,7 @@ where
 /// Contains the fields that are returned by a verifiable server batch evaluate
 #[derive_where(Debug; <CS::Group as Group>::Scalar, <CS::Group as Group>::Elem)]
 #[cfg(feature = "alloc")]
-pub struct VoprfServerBatchEvaluateResult<CS: CipherSuite>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+pub struct VoprfServerBatchEvaluateResult<CS: CipherSuite> {
     /// The messages to send to the client
     pub messages: Vec<EvaluationElement<CS>>,
     /// The proof for the client to verify
@@ -472,8 +443,6 @@ pub type VoprfServerBatchEvaluateFinishedMessages<'a, CS, I> = Map<
 #[derive_where(Debug; <&'a I as IntoIterator>::IntoIter, <CS::Group as Group>::Scalar)]
 pub struct VoprfServerBatchEvaluateFinishResult<'a, CS: 'a + CipherSuite, I>
 where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     &'a I: IntoIterator<Item = &'a PreparedEvaluationElement<CS>>,
 {
     /// The [`EvaluationElement`]s to send to the client
@@ -511,8 +480,6 @@ fn verifiable_unblind<'a, CS: 'a + CipherSuite, IC, IM>(
     proof: &Proof<CS>,
 ) -> Result<VoprfUnblindResult<'a, CS, IC, IM>>
 where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
     &'a IC: 'a + IntoIterator<Item = &'a VoprfClient<CS>>,
     <&'a IC as IntoIterator>::IntoIter: ExactSizeIterator,
     &'a IM: 'a + IntoIterator<Item = &'a EvaluationElement<CS>>,
@@ -554,11 +521,7 @@ fn finalize_after_unblind<
     IE: 'a + Iterator<Item = (I, <CS::Group as Group>::Elem)>,
 >(
     inputs_and_unblinded_elements: IE,
-) -> FinalizeAfterUnblindResult<'a, CS, I, IE>
-where
-    <CS::Hash as OutputSizeUser>::OutputSize:
-        IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-{
+) -> FinalizeAfterUnblindResult<'a, CS, I, IE> {
     inputs_and_unblinded_elements.map(|(input, unblinded_element)| {
         let elem_len = <CS::Group as Group>::ElemLen::U16.to_be_bytes();
 
@@ -583,13 +546,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Add;
     use core::ptr;
 
     use ::alloc::vec;
     use ::alloc::vec::Vec;
-    use generic_array::typenum::Sum;
-    use generic_array::ArrayLength;
     use rand::rngs::OsRng;
 
     use super::*;
@@ -600,11 +560,7 @@ mod tests {
         input: &[u8],
         key: <CS::Group as Group>::Scalar,
         mode: Mode,
-    ) -> Output<CS::Hash>
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    ) -> Output<CS::Hash> {
         let dst = Dst::new::<CS, _, _>(STR_HASH_TO_GROUP, mode);
         let point = CS::Group::hash_to_curve::<CS::Hash>(&[input], &dst.as_dst()).unwrap();
 
@@ -616,11 +572,7 @@ mod tests {
             .unwrap()
     }
 
-    fn verifiable_retrieval<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_retrieval<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = VoprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -639,11 +591,7 @@ mod tests {
         assert_eq!(client_finalize_result, res2);
     }
 
-    fn verifiable_batch_retrieval<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_batch_retrieval<CS: CipherSuite>() {
         let mut rng = OsRng;
         let mut inputs = vec![];
         let mut client_states = vec![];
@@ -687,11 +635,7 @@ mod tests {
         assert_eq!(client_finalize_result, res2);
     }
 
-    fn verifiable_batch_bad_public_key<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_batch_bad_public_key<CS: CipherSuite>() {
         let mut rng = OsRng;
         let mut inputs = vec![];
         let mut client_states = vec![];
@@ -727,11 +671,7 @@ mod tests {
         assert!(client_finalize_result.is_err());
     }
 
-    fn verifiable_bad_public_key<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_bad_public_key<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = VoprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -751,11 +691,7 @@ mod tests {
         assert!(client_finalize_result.is_err());
     }
 
-    fn verifiable_server_evaluate<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-    {
+    fn verifiable_server_evaluate<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = VoprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -784,13 +720,7 @@ mod tests {
         assert!(client_finalize != server_evaluate);
     }
 
-    fn zeroize_voprf_client<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ElemLen>: ArrayLength<u8>,
-    {
+    fn zeroize_voprf_client<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = VoprfClient::<CS>::blind(input, &mut rng).unwrap();
@@ -804,15 +734,7 @@ mod tests {
         assert!(message.serialize().iter().all(|&x| x == 0));
     }
 
-    fn zeroize_voprf_server<CS: CipherSuite>()
-    where
-        <CS::Hash as OutputSizeUser>::OutputSize:
-            IsLess<U256> + IsLessOrEqual<<CS::Hash as BlockSizeUser>::BlockSize>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ElemLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ElemLen>: ArrayLength<u8>,
-        <CS::Group as Group>::ScalarLen: Add<<CS::Group as Group>::ScalarLen>,
-        Sum<<CS::Group as Group>::ScalarLen, <CS::Group as Group>::ScalarLen>: ArrayLength<u8>,
-    {
+    fn zeroize_voprf_server<CS: CipherSuite>() {
         let input = b"input";
         let mut rng = OsRng;
         let client_blind_result = VoprfClient::<CS>::blind(input, &mut rng).unwrap();


### PR DESCRIPTION
- Update MSRV to v1.83. Now a lot of our trait constraints aren't viral anymore, but are implied! This gets rid of all the `where` constraints on structs and implementations!
- With the new MSRV, we can now implement `Error` for our error types without `std` as well.
- Move de/serialization constraints on implementations directly onto `Group`, now that the constraints aren't viral anymore.

This is a huge improvement to the documentation as well, which was littered with these huge `where`-clauses.