### PR TITLE
Enable `curve25519-dalek/serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ danger = []
 default = ["ristretto255-ciphersuite", "dep:serde"]
 ristretto255 = ["dep:curve25519-dalek", "generic-array/more_lengths"]
 ristretto255-ciphersuite = ["ristretto255", "dep:sha2"]
-serde = ["generic-array/serde", "dep:serde"]
+serde = ["curve25519-dalek?/serde", "generic-array/serde", "dep:serde"]
 std = ["alloc"]
 
 [dependencies]


### PR DESCRIPTION
Currently users would have to depend manually on `curve25519-dalek` to enable Serde.

This seems to have been lost back in https://github.com/facebook/voprf/pull/28, I suspect because enabling crate features on optional dependencies with `?` wasn't available back then.

Analogous to https://github.com/facebook/opaque-ke/pull/375.