### PR TITLE
Align `Ristretto255::random_scalar()` with specification

### DIFF
--- a/src/group/ristretto.rs
+++ b/src/group/ristretto.rs
@@ -96,9 +96,10 @@ impl Group for Ristretto255 {
 
     fn random_scalar<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
         loop {
-            let scalar = Scalar::random(rng);
+            let mut scalar_bytes = [0u8; 32];
+            rng.fill_bytes(&mut scalar_bytes);
 
-            if scalar != Scalar::ZERO {
+            if let Ok(scalar) = Self::deserialize_scalar(&scalar_bytes) {
                 break scalar;
             }
         }


### PR DESCRIPTION
The [specification states](https://www.rfc-editor.org/rfc/rfc9497#name-rejection-sampling):
> Generate a random byte array with Ns bytes and attempt to map to a Scalar by calling `DeserializeScalar` in constant time. If it succeeds, return the result. If it fails, try again with another random byte array until the procedure succeeds.

While the `elliptic-curve` implementation did just that, the `curve25519-dalek` did not, instead it simply reduced to a correct scalar. The specification proposes an [alternative to rejection sampling](https://www.rfc-editor.org/rfc/rfc9497#name-random-number-generation-us), however for Ristretto255 it requires reducing from 48 bytes, the `curve25519-dalek` implementation was reducing from 64 bytes.

With the help of `FromOkm` we might want to consider switching to a constant-time implementation instead. However I'm awaiting feedback on this errata: https://www.rfc-editor.org/errata/eid8393.