### PR TITLE
Fixing docs issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@
 //!     (https://docs.rs/curve25519-dalek/4.0.0-pre.5/curve25519_dalek/index.html#backends)
 
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(test), deny(unsafe_code))]
 #![warn(
     clippy::cargo,


### PR DESCRIPTION
Docs failed to build: https://docs.rs/crate/voprf/0.6.0-pre.0

doc_auto_cfg -> doc_cfg